### PR TITLE
Fixed formatting in hex mode

### DIFF
--- a/hotp_test.go
+++ b/hotp_test.go
@@ -20,9 +20,9 @@ func TestHOTP_Verify(t *testing.T) {
 }
 
 func TestHOTP_Hex(t *testing.T) {
-	otpHex := NewHOTP("4S62BZNFXXSZLCRO", 6, nil, FormatHex)
-	otp := otpHex.At(12345)
-	if "02f5d1" != otp {
+	otpHex := NewHOTP("KZOSZD7X6RG7HWZUQI2KBJULFU", 8, nil, FormatHex)
+	otp := otpHex.At(0)
+	if "07a45595" != otp {
 		t.Errorf("HOTP generate otp error: %v", otp)
 	}
 }

--- a/otp.go
+++ b/otp.go
@@ -20,6 +20,7 @@ type OTP struct {
 	digits     int     // number of integers in the OTP. Some apps expect this to be 6 digits, others support more.
 	hasher     *Hasher // digest function to use in the HMAC (expected to be sha1)
 	formatting string  // Saves the format an OTP is generated with
+	format     Format
 }
 
 // Format sets the output format of the OTP
@@ -55,6 +56,7 @@ func NewOTP(secret string, digits int, hasher *Hasher, format Format) OTP {
 		digits:     digits,
 		hasher:     hasher,
 		formatting: formatting,
+		format:     format,
 	}
 }
 
@@ -80,7 +82,9 @@ func (o *OTP) generateOTP(input int) string {
 		((int(hmacHash[offset+2] & 0xff)) << 8) |
 		(int(hmacHash[offset+3]) & 0xff)
 
-	code = code % int(math.Pow10(o.digits))
+	if o.format == FormatDec {
+		code = code % int(math.Pow10(o.digits))
+	}
 	return fmt.Sprintf(o.formatting, code)
 }
 


### PR DESCRIPTION
Bug caused the hex format to fail as a result of the rounding to decimal.